### PR TITLE
Set UID / GID at build time

### DIFF
--- a/docker-intellij-ultimate/Dockerfile
+++ b/docker-intellij-ultimate/Dockerfile
@@ -89,7 +89,9 @@ RUN echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.d/60-jetbr
 
 
 # user developer
-ENV USER=developer UID=1000 GID=1000
+ARG UID=1000
+ARG GID=1000
+ENV USER=developer UID=${UID} GID=${GID}
 RUN groupadd -g ${GID} ${USER} && \
        useradd -u ${UID} -g ${GID} -G sudo -m ${USER} && \
        echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} && \


### PR DESCRIPTION
Developer UID/GID are now always freely defined ... we should be able to set them explicitly.

% docker build --build-arg UID=1001 --build-arg GID=1001